### PR TITLE
Update TwoFactorChallenge.php

### DIFF
--- a/src/Http/Livewire/TwoFactorChallenge.php
+++ b/src/Http/Livewire/TwoFactorChallenge.php
@@ -61,7 +61,7 @@ class TwoFactorChallenge extends Component
      * @param \Illuminate\Contracts\Auth\StatefulGuard $guard
      * @return \Illuminate\Http\RedirectResponse
      */
-    public function authenticate(StatefulGuard $guard = null)
+    public function authenticate(?StatefulGuard $guard = null)
     {
         $guard = $guard ?: Auth::guard();
         $this->resetErrorBag();


### PR DESCRIPTION
fix PHP's deprecation warning in TwoFactorChallenge authenticate Implicitly marking parameter $guard as nullable is deprecated, the explicit nullable type must be used instead